### PR TITLE
Fix `chroot.c: fork() failed: Resource temporarily unavailable`.

### DIFF
--- a/avahi-daemon.conf
+++ b/avahi-daemon.conf
@@ -65,4 +65,3 @@ rlimit-data=4194304
 rlimit-fsize=0
 rlimit-nofile=768
 rlimit-stack=4194304
-rlimit-nproc=3


### PR DESCRIPTION
Fix `chroot.c: fork() failed: Resource temporarily unavailable` as per https://github.com/lxc/lxc/issues/25.
